### PR TITLE
fix error when starting Opera on OS X

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,10 @@ var findWindowsOperaExecutable = function () {
 
   var executable = null
   var found = defaultPaths.some(function (progFiles) {
+    if (progFiles === undefined) {
+      return false
+    }
+
     var oP = path.join(progFiles, 'Opera')
     try {
       fs.statSync(oP)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var fs = require('fs')
 var path = require('path')
 
-var PREFS = fs.readFileSync('./config/prefs.ini')
+var PREFS = fs.readFileSync(path.join(__dirname, '/config/prefs.ini'))
 
 var OperaBrowser = function (baseBrowserDecorator) {
   baseBrowserDecorator(this)


### PR DESCRIPTION
This pull request fixes [this issue](https://github.com/karma-runner/karma-opera-launcher/issues/7) (at least for me). It uses path.join() in combination with __dirname to localize the prefs.ini file. Besides that it also does not try to find the Windows executable anymore if the env variables `ProgramFiles` and `ProgramFiles(X86)` are undefined.

I have not tested if it still works on Windows.